### PR TITLE
MaxMind requires HTTPS for database downloads

### DIFF
--- a/ConfigServer/Config.pm
+++ b/ConfigServer/Config.pm
@@ -333,9 +333,9 @@ sub loadconfig {
 
 	$config{cc_src} = "MaxMind";
 	$config{asn_src} = "MaxMind";
-	$config{cc_country} = "http://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country-CSV&suffix=zip&license_key=$config{MM_LICENSE_KEY}";
-	$config{cc_city} = "http://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City-CSV&suffix=zip&license_key=$config{MM_LICENSE_KEY}";
-	$config{cc_asn} = "http://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN-CSV&suffix=zip&license_key=$config{MM_LICENSE_KEY}";
+	$config{cc_country} = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country-CSV&suffix=zip&license_key=$config{MM_LICENSE_KEY}";
+	$config{cc_city} = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City-CSV&suffix=zip&license_key=$config{MM_LICENSE_KEY}";
+	$config{cc_asn} = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN-CSV&suffix=zip&license_key=$config{MM_LICENSE_KEY}";
 	if ($config{CC_SRC} eq "2") {
 		$config{cc_src} = "DB-IP";
 		$config{asn_src} = "iptoasn.com";


### PR DESCRIPTION
MaxMind will be requiring HTTPS for all database download requests starting in March 2024.

See [this release note](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023).